### PR TITLE
vscode: add js config

### DIFF
--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -10,5 +10,14 @@
     "window.title": "${activeEditorLong}",
     "git.autofetch": true,
     "editor.minimap.enabled": false,
-    "workbench.colorTheme": "Argon — Noble Theme"
+    "workbench.colorTheme": "Argon — Noble Theme",
+    // open JSON editor instead of visual picker
+    "workbench.settings.editor": "json",
+    "editor.formatOnSave": true,
+    // disable validate because of TSLint and ESLint collision
+    "javascript.validate.enable": false,
+    "prettier.eslintIntegration": true,
+    // reduce visual noise in the left sidebar
+    "workbench.activityBar.visible": false,
+    "gitlens.codeLens.enabled": false,
 }


### PR DESCRIPTION
- make the JSON view the default to open VS Code settings
- enable format on save
- disable javascript validation (TSLint stomps on ESLint)
- enable eslint prettier integration
- disable activity bar 
- disable codelens