### PR TITLE
add ssh config common and make targets

### DIFF
--- a/ssh/Makefile
+++ b/ssh/Makefile
@@ -1,0 +1,5 @@
+ln-ssh-config-common:
+	ln -s $(PWD)/ssh_config_common $(HOME)/.ssh/config_common
+
+clean:
+	rm $(HOME)/.ssh/config_common

--- a/ssh/ssh_config_common
+++ b/ssh/ssh_config_common
@@ -1,0 +1,7 @@
+Host gitlab.com
+    IdentityFile ~/.ssh/gitlab.key
+    User git
+    
+Host github.com
+    IdentityFile ~/.ssh/github.key
+    User git


### PR DESCRIPTION
add something that writes `Include ~/.ssh/config_common` to ~/.ssh/config?