### PR TITLE
add zk script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,13 @@ VSCODECFGDIR := $(HOME)/Library/Application\ Support/Code/User
 
 init:
 	test -L $(HOME)/.zshrc || ln -s $(PWD)/zsh/zshrc.zsh $(HOME)/.zshrc
-	test -d $(HOME).hammerspoon || ln -s $(PWD)/hammerspoon $(HOME)/.hammerspoon
+	test -d $(HOME)/.hammerspoon || ln -s $(PWD)/hammerspoon $(HOME)/.hammerspoon
 	test -L $(VSCODECFGDIR)/settings.json || ln -s $(PWD)/vscode/settings.json $(VSCODECFGDIR)/settings.json
 	test -L $(VSCODECFGDIR)/keybindings.json || ln -s $(PWD)/vscode/keybindings.json $(VSCODECFGDIR)/keybindings.json
 	test -L $(VSCODECFGDIR)/projects.json || ln -s $(PWD)/vscode/projects.json $(VSCODECFGDIR)/projects.json
-	test -d $(VSCODECFGDIR)/snippets || ln -s $(PWD)/vscode/snippets $(VSCODECFGDIR)/snippets
 	test -L $(HOME)/.ssh/config_common || ln -s $(PWD)/ssh/config_common $(HOME)/.ssh/config_common
 	test -L $(HOME)/.gitconfig || ln -s $(PWD)/gitconfig $(HOME)/.gitconfig
+	test -L $(HOME)/bin/zk || ln -s $(PWD)/bin/zk $(HOME)/bin/zk
 
 clean:
 	rm -rf $(HOME)/.zshrc

--- a/bin/zk
+++ b/bin/zk
@@ -1,0 +1,50 @@
+#!/usr/local/bin/node
+
+// First run at a ZettelKestan script for creating a note from anywhere and opening it in VS Code
+
+const path = require("path");
+const child_process = require("child_process");
+const fs = require("fs");
+
+if (!process.argv[2]) {
+  throw new Error(
+    `zk requires a string wrapped in " " as an argument for a note title.`
+  );
+}
+
+const note_title = process.argv[2];
+
+const NOTEBOOK_DIR = path.join(require("os").homedir(), "Dropbox", "notebook");
+const INBOX_DIR = path.join(NOTEBOOK_DIR, "!inbox");
+
+const slug = note_title
+  .trim()
+  .toLowerCase()
+  .replace(/[^a-zA-Z0-9 ]+/g, "")
+  .replace(/\s+/g, "-");
+
+const maybeAddZero = (val) => {
+  return val < 10 ? `0${val}` : val;
+};
+
+const getTimestamp = () => {
+  const date = new Date();
+  const year = date.getFullYear();
+  const month = maybeAddZero(date.getMonth() + 1);
+  const day = maybeAddZero(date.getDate());
+  const hour = maybeAddZero(date.getHours());
+  const minute = maybeAddZero(date.getMinutes());
+  return `${year}${month}${day}${hour}${minute}`;
+};
+
+const timestamp = getTimestamp();
+
+const filepath = path.join(INBOX_DIR, `${timestamp}-${slug}.md`);
+
+try {
+  fs.writeFileSync(filepath, `# ${timestamp} ${note_title}`);
+} catch (err) {
+  throw new Error(`unable to write file: ${err.stack}`);
+}
+
+child_process.exec(`code ${filepath}`);


### PR DESCRIPTION
I've started using ZettelKestan for keeping notes. This is my first run at scripting it out with node so that it...
- gets the timestamp
- takes the first arg (string in quotes as TITLE) and creates a slug (as SLUG)
- creates a new note in the FS for <TIMESTAMP>-<SLUG> with the contents `# <TIMESTAMP> <TITLE>`