### PR TITLE
add dotfiles bin to PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ init:
 	test -L $(VSCODECFGDIR)/projects.json || ln -s $(PWD)/vscode/projects.json $(VSCODECFGDIR)/projects.json
 	test -L $(HOME)/.ssh/config_common || ln -s $(PWD)/ssh/config_common $(HOME)/.ssh/config_common
 	test -L $(HOME)/.gitconfig || ln -s $(PWD)/gitconfig $(HOME)/.gitconfig
-	test -L $(HOME)/bin/zk || ln -s $(PWD)/bin/zk $(HOME)/bin/zk
 
 clean:
 	rm -rf $(HOME)/.zshrc

--- a/zsh/zshrc.zsh
+++ b/zsh/zshrc.zsh
@@ -12,7 +12,12 @@ export WRK="$GOPATH/src"
 export GHPATH="$WRK/github.com"
 export DOTFILES="$GHPATH/chaseadamsio/dotfiles"
 
-export PATH=/usr/local/bin:/usr/local/sbin:$GOPATH/bin:/usr/local/go/bin:$PATH
+PATH=/usr/local/go/bin:$PATH
+PATH=$GOPATH/bin:$PATH
+PATH=/usr/local/sbin:$PATH
+PATH=/usr/local/bin:$PATH
+PATH=$DOTFILES/bin:$PATH
+export PATH
 
 ### LS ###
 if ls --color > /dev/null 2>&1; then # GNU `ls`


### PR DESCRIPTION
rather than symlink the individual executables in `bin` to `~/bin`, I'm adding `DOTFILES` to `PATH`.