### PR TITLE
add tmp to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ Temporary Items
 .#*
 public_html
 
+tmp
+
 emacs.d/*
 !emacs.d/themes/
 !emacs.d/init.org


### PR DESCRIPTION
Add tmp to `.gitignore`.

I've been using tmp to do try random scripts/investigate "what's happening in this isolated example" that I don't want to even worry about accidentally ending up in a commit.